### PR TITLE
Fix monitor synchronization methods

### DIFF
--- a/src/main/java/com/penapereira/example/javamonitor/monitor/IntegerStorageMonitorImpl.java
+++ b/src/main/java/com/penapereira/example/javamonitor/monitor/IntegerStorageMonitorImpl.java
@@ -53,14 +53,14 @@ public class IntegerStorageMonitorImpl implements IntegerStorageMonitor {
 		notifyAll();
 	}
 
-	@Override
-	public void forceStop() {
-		forceStop = true;
-		notifyAll();
-	}
+       @Override
+       public synchronized void forceStop() {
+               forceStop = true;
+               notifyAll();
+       }
 
-	@Override
-	public boolean hasIntegers() {
-		return consumableInts > 0;
-	}
+       @Override
+       public synchronized boolean hasIntegers() {
+               return consumableInts > 0;
+       }
 }


### PR DESCRIPTION
## Summary
- synchronize `forceStop` and `hasIntegers` in the integer storage monitor

## Testing
- `./mvnw -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68499a69d06883319069a7be64865418