### PR TITLE
Fix SimulationController comment

### DIFF
--- a/src/main/java/com/penapereira/example/javamonitor/SimulationController.java
+++ b/src/main/java/com/penapereira/example/javamonitor/SimulationController.java
@@ -63,7 +63,7 @@ public class SimulationController {
 	}
 
 	public void initialize(UIManager userInterface) {
-		// Instance our integer storage with some integers.
+                // Instantiate our integer storage with some integers.
 		intStorage = IntegerStorageMonitorImpl.instance(integersToConsume, simulationStepMillis);
 
 		// Launch the notifier.


### PR DESCRIPTION
## Summary
- correct wording in a comment on integer storage setup in SimulationController

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6849a52a65ac8331bf74c9c4aadb1bff