### PR TITLE
Improve test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,31 @@
 	</dependencies>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+               <plugins>
+                       <plugin>
+                               <groupId>org.springframework.boot</groupId>
+                               <artifactId>spring-boot-maven-plugin</artifactId>
+                       </plugin>
+                       <plugin>
+                               <groupId>org.jacoco</groupId>
+                               <artifactId>jacoco-maven-plugin</artifactId>
+                               <version>0.8.12</version>
+                               <executions>
+                                       <execution>
+                                               <goals>
+                                                       <goal>prepare-agent</goal>
+                                               </goals>
+                                       </execution>
+                                       <execution>
+                                               <id>report</id>
+                                               <phase>test</phase>
+                                               <goals>
+                                                       <goal>report</goal>
+                                               </goals>
+                                       </execution>
+                               </executions>
+                       </plugin>
+               </plugins>
+       </build>
 
 </project>

--- a/src/test/java/com/penapereira/example/javamonitor/monitor/EmptyIntegerStorageNotifierTests.java
+++ b/src/test/java/com/penapereira/example/javamonitor/monitor/EmptyIntegerStorageNotifierTests.java
@@ -1,0 +1,50 @@
+package com.penapereira.example.javamonitor.monitor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.beans.PropertyChangeEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import com.penapereira.example.javamonitor.Constants;
+
+public class EmptyIntegerStorageNotifierTests {
+
+    @Test
+    public void runFiresFinishedWhenStorageEmpty() {
+        IntegerStorageMonitorImpl monitor = new IntegerStorageMonitorImpl(0, 0);
+        EmptyIntegerStorageNotifier notifier = new EmptyIntegerStorageNotifier(monitor);
+        AtomicBoolean notified = new AtomicBoolean(false);
+
+        notifier.addPropertyChangeListener((PropertyChangeEvent evt) -> {
+            if (Constants.FINISHED.equals(evt.getPropertyName()) && Boolean.TRUE.equals(evt.getNewValue())) {
+                notified.set(true);
+            }
+        });
+
+        notifier.run();
+        assertTrue(notified.get());
+    }
+
+    @Test
+    public void runDoesNotFireFinishedWhenForcedStop() throws Exception {
+        IntegerStorageMonitorImpl monitor = new IntegerStorageMonitorImpl(1, 0);
+        EmptyIntegerStorageNotifier notifier = new EmptyIntegerStorageNotifier(monitor);
+        AtomicBoolean notified = new AtomicBoolean(false);
+
+        notifier.addPropertyChangeListener(evt -> {
+            if (Constants.FINISHED.equals(evt.getPropertyName())) {
+                notified.set(true);
+            }
+        });
+
+        Thread t = new Thread(notifier);
+        t.start();
+        Thread.sleep(100);
+        monitor.forceStop();
+        t.join(1000);
+        assertFalse(notified.get());
+    }
+}

--- a/src/test/java/com/penapereira/example/javamonitor/monitor/IntegerStorageMonitorImplTests.java
+++ b/src/test/java/com/penapereira/example/javamonitor/monitor/IntegerStorageMonitorImplTests.java
@@ -1,10 +1,11 @@
 package com.penapereira.example.javamonitor.monitor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.penapereira.example.javamonitor.exception.ForcedStopException;
 
@@ -34,5 +35,56 @@ public class IntegerStorageMonitorImplTests {
         assertFalse(monitor.hasIntegers());
         assertEquals(0, monitor.consumeInt());
         assertFalse(monitor.hasIntegers());
+    }
+
+    @Test
+    public void waitForAllIntegersReturnsImmediatelyWhenZero() throws InterruptedException, ForcedStopException {
+        IntegerStorageMonitorImpl monitor = new IntegerStorageMonitorImpl(0, 0);
+        monitor.waitForAllIntegersToBeConsumed();
+        assertFalse(monitor.hasIntegers());
+    }
+
+    @Test
+    public void consumeIntThrowsWhenForceStopped() throws Exception {
+        IntegerStorageMonitorImpl monitor = new IntegerStorageMonitorImpl(1, 0);
+
+        Thread t = new Thread(() -> {
+            try {
+                monitor.consumeInt();
+                fail("Expected ForcedStopException");
+            } catch (ForcedStopException e) {
+                // expected
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+        });
+
+        t.start();
+        Thread.sleep(100);
+        monitor.forceStop();
+        t.join(1000);
+        assertFalse(t.isAlive());
+    }
+
+    @Test
+    public void waitForAllIntegersThrowsWhenForceStopped() throws Exception {
+        IntegerStorageMonitorImpl monitor = new IntegerStorageMonitorImpl(1, 0);
+
+        Thread t = new Thread(() -> {
+            try {
+                monitor.waitForAllIntegersToBeConsumed();
+                fail("Expected ForcedStopException");
+            } catch (ForcedStopException e) {
+                // expected
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+        });
+
+        t.start();
+        Thread.sleep(100);
+        monitor.forceStop();
+        t.join(1000);
+        assertFalse(t.isAlive());
     }
 }


### PR DESCRIPTION
## Summary
- convert tests to JUnit 5 and add new concurrency tests
- add EmptyIntegerStorageNotifier tests
- integrate JaCoCo coverage reporting

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6849bff00de0833181f2ab0ab46802e0